### PR TITLE
Address #2 , #3. Add support for Oculus Rift CV1

### DIFF
--- a/Claws.csproj
+++ b/Claws.csproj
@@ -33,7 +33,7 @@
     </Reference>
     <Reference Include="Assembly-CSharp">
       <HintPath>TargetReferences\Assembly-CSharp.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="BeatSaberCustomUI">
       <HintPath>TargetReferences\ModDependencies\BeatSaberCustomUI\BeatSaberCustomUI.dll</HintPath>
@@ -41,31 +41,31 @@
     </Reference>
     <Reference Include="IPA.Loader">
       <HintPath>TargetReferences\IPA.Loader.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="SongCore, Version=2.0.9.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>TargetReferences\SongCore.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System">
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>TargetReferences\UnityEngine.CoreModule.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
       <HintPath>TargetReferences\UnityEngine.ImageConversionModule.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.XRModule">
       <HintPath>TargetReferences\UnityEngine.XRModule.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Zenject">
       <HintPath>TargetReferences\Zenject.dll</HintPath>
-	  <Private>False</Private>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Claws.csproj
+++ b/Claws.csproj
@@ -33,6 +33,7 @@
     </Reference>
     <Reference Include="Assembly-CSharp">
       <HintPath>TargetReferences\Assembly-CSharp.dll</HintPath>
+	  <Private>False</Private>
     </Reference>
     <Reference Include="BeatSaberCustomUI">
       <HintPath>TargetReferences\ModDependencies\BeatSaberCustomUI\BeatSaberCustomUI.dll</HintPath>
@@ -40,25 +41,31 @@
     </Reference>
     <Reference Include="IPA.Loader">
       <HintPath>TargetReferences\IPA.Loader.dll</HintPath>
+	  <Private>False</Private>
     </Reference>
     <Reference Include="SongCore, Version=2.0.9.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>TargetReferences\SongCore.dll</HintPath>
+	  <Private>False</Private>
     </Reference>
     <Reference Include="System">
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>TargetReferences\UnityEngine.CoreModule.dll</HintPath>
+	  <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
       <HintPath>TargetReferences\UnityEngine.ImageConversionModule.dll</HintPath>
+	  <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.XRModule">
       <HintPath>TargetReferences\UnityEngine.XRModule.dll</HintPath>
+	  <Private>False</Private>
     </Reference>
     <Reference Include="Zenject">
       <HintPath>TargetReferences\Zenject.dll</HintPath>
+	  <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Claws.csproj
+++ b/Claws.csproj
@@ -32,7 +32,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>TargetReferences\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BeatSaberCustomUI">
@@ -40,30 +40,29 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="IPA.Loader">
-      <HintPath>TargetReferences\IPA.Loader.dll</HintPath>
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="SongLoader">
-      <HintPath>TargetReferences\ModDependencies\SongLoader\SongLoader.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="SongCore">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Plugins\SongCore.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>TargetReferences\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>TargetReferences\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.XRModule">
-      <HintPath>TargetReferences\UnityEngine.XRModule.dll</HintPath>
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.XRModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Zenject">
-      <HintPath>TargetReferences\Zenject.dll</HintPath>
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Zenject.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/Claws.csproj
+++ b/Claws.csproj
@@ -32,38 +32,33 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>TargetReferences\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="BeatSaberCustomUI">
       <HintPath>TargetReferences\ModDependencies\BeatSaberCustomUI\BeatSaberCustomUI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="IPA.Loader">
-      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>TargetReferences\IPA.Loader.dll</HintPath>
     </Reference>
-    <Reference Include="SongCore">
-      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Plugins\SongCore.dll</HintPath>
+    <Reference Include="SongCore, Version=2.0.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>TargetReferences\SongCore.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>TargetReferences\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>TargetReferences\UnityEngine.ImageConversionModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.XRModule">
-      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.XRModule.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>TargetReferences\UnityEngine.XRModule.dll</HintPath>
     </Reference>
     <Reference Include="Zenject">
-      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Zenject.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>TargetReferences\Zenject.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Gamemode.cs
+++ b/Gamemode.cs
@@ -68,9 +68,10 @@ namespace Claws
         void UpdateCapability()
         {
             if (Plugin.IsEnabled)
-                SongLoaderPlugin.SongLoader.RegisterCapability(Plugin.CapabilityName);
+                SongCore.Collections.RegisterCapability(Plugin.CapabilityName);
+
             else
-                SongLoaderPlugin.SongLoader.DeregisterizeCapability(Plugin.CapabilityName);
+                SongCore.Collections.DeregisterizeCapability(Plugin.CapabilityName);
         }
     }
 }

--- a/Modifiers/SaberGrip.cs
+++ b/Modifiers/SaberGrip.cs
@@ -14,7 +14,7 @@ namespace Claws.Modifiers
             LeftSaber = null;
             RightSaber = null;
 
-            Plugin.Log("Setting up grip adjustments...");
+            Plugin.Log.Info("Setting up grip adjustments...");
 
             var saberManagerObj = gameCore.transform
                 .Find("Origin")
@@ -23,7 +23,7 @@ namespace Claws.Modifiers
 
             if (saberManagerObj == null)
             {
-                Plugin.Log("Couldn't find SaberManager, bailing!");
+                Plugin.Log.Critical("Couldn't find SaberManager, bailing!");
                 return;
             }
 
@@ -34,11 +34,11 @@ namespace Claws.Modifiers
 
             if (LeftSaber is null || RightSaber is null)
             {
-                Plugin.Log("Sabers couldn't be found. Bailing!");
+                Plugin.Log.Critical("Sabers couldn't be found. Bailing!");
                 return;
             }
 
-            Plugin.Log("Grip adjustments ready!");
+            Plugin.Log.Info("Grip adjustments ready!");
         }
     }
 

--- a/Modifiers/SaberLength.cs
+++ b/Modifiers/SaberLength.cs
@@ -13,7 +13,7 @@ namespace Claws.Modifiers
             _leftSaber = null;
             _rightSaber = null;
 
-            Plugin.Log("Setting up length adjustments...");
+            Plugin.Log.Info("Setting up length adjustments...");
 
             var saberManagerObj = gameCore.transform
                 .Find("Origin")
@@ -22,7 +22,7 @@ namespace Claws.Modifiers
 
             if (saberManagerObj == null)
             {
-                Plugin.Log("Couldn't find SaberManager, bailing!");
+                Plugin.Log.Critical("Couldn't find SaberManager, bailing!");
                 return;
             }
 
@@ -33,16 +33,16 @@ namespace Claws.Modifiers
 
             if (_leftSaber is null || _rightSaber is null)
             {
-                Plugin.Log("Sabers couldn't be found. Bailing!");
+                Plugin.Log.Critical("Sabers couldn't be found. Bailing!");
                 return;
             }
 
-            Plugin.Log("Length adjustments ready!");
+            Plugin.Log.Info("Length adjustments ready!");
         }
 
         internal void SetLength(float length)
         {
-            Plugin.Log($"Setting sabers length to {length:0.00}m");
+            Plugin.Log.Debug($"Setting sabers length to {length:0.00}m");
 
             if (_leftSaber != null)
                 SetSaberLength(_leftSaber, length);

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,5 +1,6 @@
 ﻿using Harmony;
 using IPA;
+using IPALogger = IPA.Logging.Logger;
 using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -55,8 +56,8 @@ namespace Claws
             }
             catch (Exception e)
             {
-                Log("This plugin requires Harmony. Make sure you installed the plugin properly, as the Harmony DLL should have been installed with it.");
-                Log(e.ToString());
+                Log.Error("This plugin requires Harmony. Make sure you installed the plugin properly, as the Harmony DLL should have been installed with it.");
+                Log.Error(e.ToString());
 
                 return;
             }
@@ -68,7 +69,7 @@ namespace Claws
 
             _gamemode = new Gamemode();
 
-            Log($"v{Version} loaded!");
+            Log.Info($"v{Version} loaded!");
         }
 
         void IBeatSaberPlugin.OnApplicationQuit()
@@ -79,21 +80,21 @@ namespace Claws
 
         static void StorePlayerPrefs()
         {
-            Log("Storing plugin preferences...");
+            Log.Info("Storing plugin preferences...");
 
             PlayerPrefs.SetInt(IsEnabledPreference, IsEnabled ? 1 : 0);
             PlayerPrefs.Save();
 
-            Log("Stored!");
+            Log.Info("Stored!");
         }
         static void RestorePlayerPrefs()
         {
-            Log("Loading plugin preferences...");
+            Log.Info("Loading plugin preferences...");
 
             IsEnabled = PlayerPrefs.GetInt(IsEnabledPreference, 0) != 0;
 
             var pluginState = IsEnabled ? "enabled" : "disabled";
-            Log($"Loaded! Plugin is {pluginState}.");
+            Log.Info($"Loaded! Plugin is {pluginState}.");
         }
 
         static void LoadIcon()
@@ -112,7 +113,7 @@ namespace Claws
         {
             resourceName = @"Claws.Resources." + resourceName;
 
-            Log($"Loading embedded resource: {resourceName}");
+            Log.Info($"Loading embedded resource: {resourceName}");
 
             using (var resourceStream = Assembly.GetManifestResourceStream(resourceName))
             {
@@ -122,22 +123,23 @@ namespace Claws
 
                 resourceStream.Read(resource, 0, resource.Length);
 
-                Log($"Loaded {resourceName}");
+                Log.Info($"Loaded {resourceName}");
 
                 return resource;
             }
         }
 
 
-        internal static void Log(string message)
-        {
-            Console.WriteLine($"[{Name}] {message}");
-        }
+     
+       public static IPALogger Log { get; internal set; }
 
+    public void Init(object thisIsNull, IPALogger log)
+    {
+        Log = log;
+    }
+    #region Unused IPlugin Members
 
-        #region Unused IPlugin Members
-
-        void IBeatSaberPlugin.OnUpdate() { }
+    void IBeatSaberPlugin.OnUpdate() { }
         void IBeatSaberPlugin.OnFixedUpdate() { }
         void IBeatSaberPlugin.OnActiveSceneChanged(Scene from, Scene to) { }
         void IBeatSaberPlugin.OnSceneLoaded(Scene scene, LoadSceneMode mode) { }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -40,7 +40,12 @@ namespace Claws
         internal static Sprite IconSprite { get; private set; }
 
         static Texture2D _iconTexture;
+        public static IPALogger Log { get; internal set; }
 
+        public void Init(object thisIsNull, IPALogger log)
+        {
+            Log = log;
+        }
 
         void IBeatSaberPlugin.OnApplicationStart()
         {
@@ -130,13 +135,6 @@ namespace Claws
         }
 
 
-     
-       public static IPALogger Log { get; internal set; }
-
-    public void Init(object thisIsNull, IPALogger log)
-    {
-        Log = log;
-    }
     #region Unused IPlugin Members
 
     void IBeatSaberPlugin.OnUpdate() { }

--- a/Preferences.cs
+++ b/Preferences.cs
@@ -51,18 +51,39 @@ namespace Claws
 
         public static void Invalidate()
         {
-            Plugin.Log("Refreshing user preferences...");
+
+            LeftTranslation = Vector3.zero;
+            LeftRotation = Vector3.zero;
+            var controllerType = GetActiveControllersType();
+
+            Plugin.Log.Debug($"Applying default offsets for {controllerType} controllers!");
+
+            if (DefaultTranslation.ContainsKey(controllerType))
+                LeftTranslation = DefaultTranslation[controllerType];
+
+            if (DefaultRotation.ContainsKey(controllerType))
+                LeftRotation = DefaultRotation[controllerType];
+
+            RightTranslation = MirrorTranslation(LeftTranslation);
+            RightRotation = MirrorRotation(LeftRotation);
+        }
+        /* Removed this in case anyone wanted to inject their own preferences. 
+         * I'd prefer that folks Claws experiences be the same throughout.
+        public static void Invalidate_old()
+        {
+            Plugin.Log.Debug("Refreshing user preferences...");
 
             LeftTranslation = Vector3.zero;
             LeftRotation = Vector3.zero;
 
-            var userTranslationString = ModPrefs.GetString(PrefsSection, TranslationKey);
-            var userRotationString = ModPrefs.GetString(PrefsSection, RotationKey);
+
+            String userTranslationString = ModPrefs.GetString(PrefsSection, TranslationKey);
+            String userRotationString = ModPrefs.GetString(PrefsSection, RotationKey);
 
             // When any user preference exists, ignore all defaults.
             if (!string.IsNullOrWhiteSpace(userTranslationString) || !string.IsNullOrWhiteSpace(userRotationString))
             {
-                Plugin.Log("Applying user offsets...");
+                Plugin.Log.Debug("Applying user offsets...");
 
                 if (!string.IsNullOrWhiteSpace(userTranslationString))
                     LeftTranslation = ParseVector3(userTranslationString);
@@ -72,20 +93,12 @@ namespace Claws
             }
             else
             {
-                var controllerType = GetActiveControllersType();
-
-                Plugin.Log($"Applying default offsets for {controllerType} controllers!");
-
-                if (DefaultTranslation.ContainsKey(controllerType))
-                    LeftTranslation = DefaultTranslation[controllerType];
-
-                if (DefaultRotation.ContainsKey(controllerType))
-                    LeftRotation = DefaultRotation[controllerType];
+                Invalidate();
             }
 
             RightTranslation = MirrorTranslation(LeftTranslation);
             RightRotation = MirrorRotation(LeftRotation);
-        }
+        }*/
 
         static VRControllerType GetActiveControllersType()
         {
@@ -134,7 +147,12 @@ namespace Claws
                 if (controller.IndexOf(@"Knuckles", StringComparison.InvariantCultureIgnoreCase) >= 0)
                     return VRControllerType.Knuckles;
 
+<<<<<<< Updated upstream
                 Plugin.Log("Discovering controller: " + controller.ToString() + "failed! please open an issue with this log statement");
+=======
+                Plugin.Log.Error("Discovering controller: " + controller.ToString() + "failed! please open an issue with this log statement"
+                    );
+>>>>>>> Stashed changes
             }
 
             return VRControllerType.Unknown;

--- a/Preferences.cs
+++ b/Preferences.cs
@@ -67,38 +67,6 @@ namespace Claws
             RightTranslation = MirrorTranslation(LeftTranslation);
             RightRotation = MirrorRotation(LeftRotation);
         }
-        /* Removed this in case anyone wanted to inject their own preferences. 
-         * I'd prefer that folks Claws experiences be the same throughout.
-        public static void Invalidate_old()
-        {
-            Plugin.Log.Debug("Refreshing user preferences...");
-
-            LeftTranslation = Vector3.zero;
-            LeftRotation = Vector3.zero;
-
-
-            String userTranslationString = ModPrefs.GetString(PrefsSection, TranslationKey);
-            String userRotationString = ModPrefs.GetString(PrefsSection, RotationKey);
-
-            // When any user preference exists, ignore all defaults.
-            if (!string.IsNullOrWhiteSpace(userTranslationString) || !string.IsNullOrWhiteSpace(userRotationString))
-            {
-                Plugin.Log.Debug("Applying user offsets...");
-
-                if (!string.IsNullOrWhiteSpace(userTranslationString))
-                    LeftTranslation = ParseVector3(userTranslationString);
-
-                if (!string.IsNullOrWhiteSpace(userRotationString))
-                    LeftRotation = ParseVector3(userRotationString);
-            }
-            else
-            {
-                Invalidate();
-            }
-
-            RightTranslation = MirrorTranslation(LeftTranslation);
-            RightRotation = MirrorRotation(LeftRotation);
-        }*/
 
         static VRControllerType GetActiveControllersType()
         {

--- a/Preferences.cs
+++ b/Preferences.cs
@@ -1,4 +1,4 @@
-﻿using IPA.Config;
+using IPA.Config;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -15,6 +15,7 @@ namespace Claws
         Touch,
         WMR,
         Knuckles,
+        OculusStoreTouch,
     }
 
     internal static class Preferences
@@ -34,16 +35,18 @@ namespace Claws
         static readonly Dictionary<VRControllerType, Vector3> DefaultTranslation = new Dictionary<VRControllerType, Vector3>
         {
             { VRControllerType.Unknown,      Vector3.zero },
-            { VRControllerType.Vive,     new Vector3(-0.04f, -0.0125f, -0.06f) },
-            { VRControllerType.Touch,    new Vector3(-0.03f, -0.0225f, -0.095f) },
-            { VRControllerType.Knuckles, new Vector3(-0.04f, -0.0225f, -0.11f) }
+            { VRControllerType.Vive,      new Vector3(-0.04f, -0.0125f, -0.06f) },
+            { VRControllerType.Touch,    new Vector3(-0.03f, -0.0225f, -0.095f ) },
+            { VRControllerType.Knuckles, new Vector3(-0.04f, -0.0225f, -0.11f) },
+            { VRControllerType.OculusStoreTouch, new Vector3(-0.1f, -0.0225f, -0.06f) }
         };
         static readonly Dictionary<VRControllerType, Vector3> DefaultRotation = new Dictionary<VRControllerType, Vector3>
         {
             { VRControllerType.Unknown,      Vector3.zero },
-            { VRControllerType.Vive,     new Vector3(75f, 0f, 90f) },
-            { VRControllerType.Touch,    new Vector3(75f, 0f, 90f) },
-            { VRControllerType.Knuckles, new Vector3(75f, 0f, 90f) }
+            { VRControllerType.Vive,      new Vector3(75f, 0f, 90f) },
+            { VRControllerType.Touch,    new Vector3(75f, 0f, 90f ) },
+            { VRControllerType.Knuckles, new Vector3(75f, 0f, 90f) },
+            { VRControllerType.OculusStoreTouch, new Vector3(25f, 0f, 90f) }
         };
 
         public static void Invalidate()
@@ -110,7 +113,12 @@ namespace Claws
                  */
                 if (controller.IndexOf(@"Oculus Rift", StringComparison.InvariantCultureIgnoreCase) >= 0)
                     return VRControllerType.Touch;
-
+                /*
+                 * Known Oculus Store controller names:
+                 *   Oculus Touch Controller
+                 */
+                if (controller.IndexOf(@"Oculus Touch", StringComparison.InvariantCultureIgnoreCase) >=0)
+                    return VRControllerType.OculusStoreTouch;
                 /*
                  * Known WMR controller names:
                  *   WindowsMR: 0x045e/0x065b/0/2
@@ -125,6 +133,8 @@ namespace Claws
                  */
                 if (controller.IndexOf(@"Knuckles", StringComparison.InvariantCultureIgnoreCase) >= 0)
                     return VRControllerType.Knuckles;
+
+                Plugin.Log("Discovering controller: " + controller.ToString() + "failed! please open an issue with this log statement");
             }
 
             return VRControllerType.Unknown;

--- a/Preferences.cs
+++ b/Preferences.cs
@@ -34,14 +34,14 @@ namespace Claws
         static readonly Dictionary<VRControllerType, Vector3> DefaultTranslation = new Dictionary<VRControllerType, Vector3>
         {
             { VRControllerType.Unknown,      Vector3.zero },
-            { VRControllerType.Vive,      new Vector3(-0.04f, -0.0125f, -0.06f) },
+            { VRControllerType.Vive,     new Vector3(-0.04f, -0.0125f, -0.06f) },
             { VRControllerType.Touch,    new Vector3(-0.03f, -0.0225f, -0.095f) },
             { VRControllerType.Knuckles, new Vector3(-0.04f, -0.0225f, -0.11f) }
         };
         static readonly Dictionary<VRControllerType, Vector3> DefaultRotation = new Dictionary<VRControllerType, Vector3>
         {
             { VRControllerType.Unknown,      Vector3.zero },
-            { VRControllerType.Vive,      new Vector3(75f, 0f, 90f) },
+            { VRControllerType.Vive,     new Vector3(75f, 0f, 90f) },
             { VRControllerType.Touch,    new Vector3(75f, 0f, 90f) },
             { VRControllerType.Knuckles, new Vector3(75f, 0f, 90f) }
         };

--- a/Preferences.cs
+++ b/Preferences.cs
@@ -1,4 +1,4 @@
-using IPA.Config;
+﻿using IPA.Config;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -147,12 +147,8 @@ namespace Claws
                 if (controller.IndexOf(@"Knuckles", StringComparison.InvariantCultureIgnoreCase) >= 0)
                     return VRControllerType.Knuckles;
 
-<<<<<<< Updated upstream
-                Plugin.Log("Discovering controller: " + controller.ToString() + "failed! please open an issue with this log statement");
-=======
                 Plugin.Log.Error("Discovering controller: " + controller.ToString() + "failed! please open an issue with this log statement"
                     );
->>>>>>> Stashed changes
             }
 
             return VRControllerType.Unknown;

--- a/Preferences.cs
+++ b/Preferences.cs
@@ -34,13 +34,15 @@ namespace Claws
         static readonly Dictionary<VRControllerType, Vector3> DefaultTranslation = new Dictionary<VRControllerType, Vector3>
         {
             { VRControllerType.Unknown,      Vector3.zero },
-            { VRControllerType.Vive,     new Vector3(-0.04f, -0.0125f, -0.06f) },
+            { VRControllerType.Vive,      new Vector3(-0.04f, -0.0125f, -0.06f) },
+            { VRControllerType.Touch,    new Vector3(-0.03f, -0.0225f, -0.095f) },
             { VRControllerType.Knuckles, new Vector3(-0.04f, -0.0225f, -0.11f) }
         };
         static readonly Dictionary<VRControllerType, Vector3> DefaultRotation = new Dictionary<VRControllerType, Vector3>
         {
             { VRControllerType.Unknown,      Vector3.zero },
-            { VRControllerType.Vive,     new Vector3(75f, 0f, 90f) },
+            { VRControllerType.Vive,      new Vector3(75f, 0f, 90f) },
+            { VRControllerType.Touch,    new Vector3(75f, 0f, 90f) },
             { VRControllerType.Knuckles, new Vector3(75f, 0f, 90f) }
         };
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,10 +2,10 @@
   "$schema": "https://github.com/beat-saber-modding-group/BSIPA-MetadataFileSchema/master/Schema.json",
   "author": "Ruirize",
   "description": "Custom mod for Beat Saber that shortens sabers from 100cm to 30cm.",
-  "gameVersion": "0.13.2",
+  "gameVersion": "1.1.0",
   "id": "claws",
   "name": "Claws Mod",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "features": [
   ]
 }


### PR DESCRIPTION
This addresses #2 and #3  by adding support for Oculus Rift CV1 controllers in both SteamVR install and the Oculus Store install. 

Note: Defaults for Oculus vr were discovered by using the Oculus default avatar hand positioning. Based on the many ways that one can hold a controller, this could be incorrect. Defaults were created using a default hand grip for both Oculus store and SteamVR