### PR TITLE
Set parent of `ClawsModelController`

### DIFF
--- a/Modifiers/ClawsModelController.cs
+++ b/Modifiers/ClawsModelController.cs
@@ -19,6 +19,8 @@ namespace Claws.Modifiers
                     : Plugin.RightSaber,
                 parent, false);
 
+            gameObject.transform.SetParent(parent);
+
             _saber.transform.localScale = new Vector3(1, 1, Preferences.Length / 0.30f);
 
             Color = _colorManager.ColorForSaberType(saber.saberType);


### PR DESCRIPTION
Sets the parent of `ClawsModelController`. Alternatively, you could call `base.Init(parent, saber)`, but that does some other things that you may not want. This fixes an issue where Chroma cannot find the ClawsModelController and breaks some things.