### PR TITLE
Revert changes that cause orientation issues on Quest 2

### DIFF
--- a/Gamemode.cs
+++ b/Gamemode.cs
@@ -1,8 +1,9 @@
-﻿using BeatSaberMarkupLanguage.GameplaySetup;
+﻿using System;
+using BeatSaberMarkupLanguage.GameplaySetup;
 using BS_Utils.Utilities;
+using Claws.Modifiers;
 using Claws.Views;
 using SongCore;
-using System;
 
 namespace Claws
 {
@@ -29,11 +30,13 @@ namespace Claws
         void OnMenuActivated()
         {
             UpdateCapability();
+            SaberGrip.IsInGame = false;
         }
 
         void OnGameActivated()
         {
             Preferences.Invalidate();
+            SaberGrip.IsInGame = true;
         }
 
         void OnGamemodeToggled(object sender, EventArgs e)

--- a/Modifiers/ClawsModelController.cs
+++ b/Modifiers/ClawsModelController.cs
@@ -44,7 +44,6 @@ namespace Claws.Modifiers
         Saber _saber;
         GameObject _saberContainer;
         ClawTrail _trail;
-        ClawVisibilityTrackingBehaviour _visibilityTracking;
 
         public override void Init(Transform parent, Saber saber)
         {
@@ -61,9 +60,6 @@ namespace Claws.Modifiers
 
             _trail = _saberContainer.AddComponent<ClawTrail>();
             _trail.RegisterPrefab(_saberTrail.GetPrivateField<SaberTrailRenderer>("_trailRendererPrefab"));
-
-            _visibilityTracking = _saberContainer.AddComponent<ClawVisibilityTrackingBehaviour>();
-            _visibilityTracking.ForSaberType = _saber.saberType;
 
             Color = _colorManager.ColorForSaberType(_saber.saberType);
 

--- a/Modifiers/SaberGrip.cs
+++ b/Modifiers/SaberGrip.cs
@@ -6,48 +6,38 @@ namespace Claws.Modifiers
 {
     internal static class SaberGrip
     {
+        internal static bool IsInGame { get; set; }
         internal static bool IsLeftVisible { get; set; }
         internal static bool IsRightVisible { get; set; }
 
         /// <summary>
-        /// Clears base game offset whenever the sabers are visible.
+        /// When the plugin is enabled, clears player offset preferences when ingame.
         /// </summary>
-        internal static void ClearBaseGameOffsets(XRNode node, ref Vector3 position, ref Vector3 rotation)
+        internal static void ClearBaseGameOffsets(ref Vector3 position, ref Vector3 rotation)
         {
             if (!Plugin.IsEnabled) return;
-
-            switch (node)
-            {
-                case XRNode.LeftHand:
-                    if (!IsLeftVisible) return;
-                    break;
-
-                case XRNode.RightHand:
-                    if (!IsRightVisible) return;
-                    break;
-            }
+            if (!IsInGame) return;
 
             position = Vector3.zero;
             rotation = Vector3.zero;
         }
 
         /// <summary>
-        /// Applies our offsets whenever the sabers are visible.
+        /// When the plugin is enabled, applies current controller offsets when ingame.
         /// </summary>
         internal static void AdjustControllerTransform(XRNode node, Transform transform)
         {
             if (!Plugin.IsEnabled) return;
+            if (!IsInGame) return;
 
             switch (node)
             {
                 case XRNode.LeftHand:
-                    if (!IsLeftVisible) return;
                     transform.Translate(Preferences.LeftTranslation);
                     transform.Rotate(Preferences.LeftRotation);
                     break;
 
                 case XRNode.RightHand:
-                    if (!IsRightVisible) return;
                     transform.Translate(Preferences.RightTranslation);
                     transform.Rotate(Preferences.RightRotation);
                     break;
@@ -63,7 +53,7 @@ namespace Claws.Modifiers
             DevicelessVRHelper __instance,
             XRNode node, Transform transform,
             ref Vector3 position, ref Vector3 rotation
-        ) => SaberGrip.ClearBaseGameOffsets(node, ref position, ref rotation);
+        ) => SaberGrip.ClearBaseGameOffsets(ref position, ref rotation);
 
         static void Postfix(
             DevicelessVRHelper __instance,
@@ -80,7 +70,7 @@ namespace Claws.Modifiers
             OculusVRHelper __instance,
             XRNode node, Transform transform,
             ref Vector3 position, ref Vector3 rotation
-        ) => SaberGrip.ClearBaseGameOffsets(node, ref position, ref rotation);
+        ) => SaberGrip.ClearBaseGameOffsets(ref position, ref rotation);
 
         static void Postfix(
             OculusVRHelper __instance,
@@ -97,7 +87,7 @@ namespace Claws.Modifiers
             OpenVRHelper __instance,
             XRNode node, Transform transform,
             ref Vector3 position, ref Vector3 rotation
-        ) => SaberGrip.ClearBaseGameOffsets(node, ref position, ref rotation);
+        ) => SaberGrip.ClearBaseGameOffsets(ref position, ref rotation);
 
         static void Postfix(
             OpenVRHelper __instance,


### PR DESCRIPTION
Fixes the issue where the claws don't apply offsets until the menu is activated then deactivated