### PR TITLE
Updates for Beat Saber 1.38.0

### DIFF
--- a/Claws.csproj
+++ b/Claws.csproj
@@ -36,6 +36,11 @@
     <DisableZipRelease>True</DisableZipRelease>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BeatSaber.ViewSystem, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatSaber.ViewSystem.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="BSML">
       <HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
       <Private>False</Private>
@@ -66,6 +71,11 @@
     <Reference Include="Main">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="SaberTrail, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\SaberTrail.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="SemVer">
       <HintPath>$(BeatSaberDir)\Libs\SemVer.dll</HintPath>

--- a/Gamemode.cs
+++ b/Gamemode.cs
@@ -1,17 +1,21 @@
 ﻿using BeatSaberMarkupLanguage.GameplaySetup;
 using Claws.Views;
+using Zenject;
 
 namespace Claws
 {
-    internal class Gamemode
+    internal class Gamemode : IInitializable
     {
         readonly GamemodeSettingsViewController _gamemodeSettingsView;
 
         internal Gamemode()
         {
             _gamemodeSettingsView = new GamemodeSettingsViewController();
+        }
 
-            GameplaySetup.instance.AddTab(
+        public void Initialize()
+        {
+            GameplaySetup.Instance.AddTab(
                 "Claws",
                 GamemodeSettingsViewController.Resource,
                 _gamemodeSettingsView

--- a/Modifiers/ClawsModelController.cs
+++ b/Modifiers/ClawsModelController.cs
@@ -46,7 +46,7 @@ namespace Claws.Modifiers
         GameObject _saberContainer;
         ClawTrail _trail;
 
-        [InjectOptional] readonly InitData _initData = new InitData();
+        [InjectOptional] readonly SaberModelContainer.InitData _initData = new SaberModelContainer.InitData();
         [Inject] readonly ColorManager _colorManager;
 
         MaterialPropertyBlock _materialPropertyBlock;
@@ -83,7 +83,7 @@ namespace Claws.Modifiers
         {
             _color = color;
 
-            _trail.Setup((_color * _initData.trailTintColor).linear, _saber.movementData);
+            _trail.Setup((_color * _initData.trailTintColor).linear, _saber.movementDataForVisualEffects);
 
             if (_materialPropertyBlock == null)
                 _materialPropertyBlock = new MaterialPropertyBlock();

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -37,8 +37,6 @@ namespace Claws
 
         static bool _isInitialized;
 
-        static Gamemode _gamemode;
-
         [Init]
         public void Init(object _, IPALogger log, Zenjector zenjector)
         {
@@ -46,6 +44,7 @@ namespace Claws
 
             ClawsModelController.LoadSaberAsset();
 
+            zenjector.Install(Location.Menu, cont => cont.BindInterfacesTo<Gamemode>().AsSingle());
             zenjector.Install(Location.Player, container =>
             {
                 if (!IsEnabled) return;
@@ -63,8 +62,6 @@ namespace Claws
 
             Preferences.Restore();
             Preferences.Invalidate();
-
-            _gamemode = new Gamemode();
 
             Log.Info($"v{Version} loaded!");
         }


### PR DESCRIPTION
BSML menus are destroyed on internal restart so they must be reinitialized, we can use zenject's `IInitializable` to do this

`movementData` changed to 2 different properties but they both point to the same field. we'll see what they plan to do with this down the line